### PR TITLE
feat: added option to specify unique postfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The unregisterOnShutdown option allows to remove from the bridge all z2m devices
 
 These are the default vules:
 
-```
+```json
 {
   "name": "matterbridge-zigbee2mqtt",
   "type": "DynamicPlatform",
@@ -137,13 +137,14 @@ These are the default vules:
   "lightList": [],
   "outletList": [],
   "featureBlackList": [],
-  "deviceFeatureBlackList": {}
+  "deviceFeatureBlackList": {},
+  "postfixHostname": true
 }
 ```
 
 If you want to exclude "device_temperature" for all the devices, add to the config
 
-```
+```json
 {
   ...
   "featureBlackList": ["device_temperature"]
@@ -154,7 +155,7 @@ If you want to exclude "device_temperature" for all the devices, add to the conf
 If you want to exclude "temperature" and "humidity" for the device "My motion sensor" and
 "device_temperature" only for the device "My climate sensor", add to the config
 
-```
+```json
 {
   ...
   "deviceFeatureBlackList": {
@@ -162,6 +163,18 @@ If you want to exclude "temperature" and "humidity" for the device "My motion se
     "My climate sensor": ["device_temperature"]
   }
   ...
+}
+```
+
+By default matterbridge uses hostname in order to make entities unique, however in some cases
+you may not want this behavior, for example when deploying matterbridge in kubernets cluster.
+You can use "postfixHostname" boolean flag to disable this behavior:
+
+```json
+{
+    ...
+    "postfixHostname": false
+    ...
 }
 ```
 

--- a/matterbridge-zigbee2mqtt.schema.json
+++ b/matterbridge-zigbee2mqtt.schema.json
@@ -106,6 +106,11 @@
       "description": "Unregister all devices on shutdown (development only)",
       "type": "boolean",
       "default": false
+    },
+    "postfixHostname": {
+      "description": "Unique postfix added to each device identifier to avoid collision with other automation system",
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -58,6 +58,7 @@ export class ZigbeePlatform extends MatterbridgeDynamicPlatform {
   public switchList: string[] = [];
   public featureBlackList: string[] = [];
   public deviceFeatureBlackList: DeviceFeatureBlackList = {};
+  public postfixHostname = true;
 
   // zigbee2Mqtt
   public debugEnabled: boolean;
@@ -93,6 +94,8 @@ export class ZigbeePlatform extends MatterbridgeDynamicPlatform {
     if (config.outletList) this.outletList = config.outletList as string[];
     if (config.featureBlackList) this.featureBlackList = config.featureBlackList as string[];
     if (config.deviceFeatureBlackList) this.deviceFeatureBlackList = config.deviceFeatureBlackList as DeviceFeatureBlackList;
+    this.postfixHostname = (config.postfixHostname as boolean) ?? true;
+
     // Save back to create a default plugin config.json
     config.host = this.mqttHost;
     config.port = this.mqttPort;
@@ -102,6 +105,7 @@ export class ZigbeePlatform extends MatterbridgeDynamicPlatform {
     config.password = this.mqttPassword;
     config.whiteList = this.whiteList;
     config.blackList = this.blackList;
+    config.postfixHostname = this.postfixHostname;
 
     if (config.type === 'MatterbridgeExtension') {
       this.z2m = new Zigbee2MQTT(this.mqttHost, this.mqttPort, this.mqttTopic, this.mqttUsername, this.mqttPassword, this.mqttProtocol, this.debugEnabled);


### PR DESCRIPTION
Currently plugin uses hostname as unique postfix, which can cause problems, for example:

- When moving matterbridge to another machine, then all Z2M entities got duplicated because they will have new serial number because of hostname change
- When deployed in Kubernetes with host network, then pod receives real machine hostname instead of pod name, this lead to the same problem - when matterbridge got deployed on another node you will get duplicates