### PR TITLE
fix: MQTT credentials are always set

### DIFF
--- a/src/zigbee2mqtt.ts
+++ b/src/zigbee2mqtt.ts
@@ -272,7 +272,7 @@ export class Zigbee2MQTT extends EventEmitter {
   };
 
   // Constructor
-  constructor(mqttHost: string, mqttPort: number, mqttTopic: string, mq ttUsername = '', mqttPassword = '', protocolVersion: 4 | 5 | 3 = 5, debug = false) {
+  constructor(mqttHost: string, mqttPort: number, mqttTopic: string, mqttUsername = '', mqttPassword = '', protocolVersion: 4 | 5 | 3 = 5, debug = false) {
     super();
 
     this.mqttHost = mqttHost;
@@ -284,6 +284,9 @@ export class Zigbee2MQTT extends EventEmitter {
     if (!!mqttUsername && !!mqttPassword) {
       this.options.username = mqttUsername;
       this.options.password = mqttPassword;
+    }
+    if (!!mqttUsername) {
+      this.options.clientId = mqttUsername;
     }
     this.options.protocolVersion = protocolVersion;
 

--- a/src/zigbee2mqtt.ts
+++ b/src/zigbee2mqtt.ts
@@ -266,13 +266,13 @@ export class Zigbee2MQTT extends EventEmitter {
     protocolVersion: 5,
     reconnectPeriod: 5000, // 1000
     connectTimeout: 60 * 1000, // 30 * 1000
-    username: '',
-    password: '',
+    username: undefined,
+    password: undefined,
     clean: true,
   };
 
   // Constructor
-  constructor(mqttHost: string, mqttPort: number, mqttTopic: string, mqttUsername = '', mqttPassword = '', protocolVersion: 4 | 5 | 3 = 5, debug = false) {
+  constructor(mqttHost: string, mqttPort: number, mqttTopic: string, mq ttUsername = '', mqttPassword = '', protocolVersion: 4 | 5 | 3 = 5, debug = false) {
     super();
 
     this.mqttHost = mqttHost;
@@ -281,7 +281,7 @@ export class Zigbee2MQTT extends EventEmitter {
     this.mqttUsername = mqttUsername;
     this.mqttPassword = mqttPassword;
 
-    if (mqttUsername !== '' && mqttPassword !== '') {
+    if (!!mqttUsername && !!mqttPassword) {
       this.options.username = mqttUsername;
       this.options.password = mqttPassword;
     }


### PR DESCRIPTION
**Problem**
When authentication is disabled in EMQX, connection fails when username and password are defaulted to empty strings.

**Description of Change**
1. Default the MQTT credentials to `undefined`.
2. Check if username and password are truthy (non-null, defined, non-empty strings), if truthy apply username and password to MQTT options.
3. Check if username is truthy (non-null, defined, non-empty string), if truthy apply username to the clientId MQTT option.