### PR TITLE
Remove default value, instead display placeholder

### DIFF
--- a/matterbridge-zigbee2mqtt.schema.json
+++ b/matterbridge-zigbee2mqtt.schema.json
@@ -51,8 +51,7 @@
       "description": "The devices in the list will not be exposed.",
       "type": "array",
       "items": {
-        "type": "string",
-        "default": "device or group name"
+        "type": "string"
       },
       "uniqueItems": true,
       "selectFrom": "name"
@@ -61,8 +60,7 @@
       "description": "Only the devices in the list will be exposed.",
       "type": "array",
       "items": {
-        "type": "string",
-        "default": "device or group name"
+        "type": "string"
       },
       "uniqueItems": true,
       "selectFrom": "name"


### PR DESCRIPTION
The default value in `blackList` and `whiteList` needs to manually deleted when entering new content.
Falling back to the same behavior as matterbridge-hass is more logical (placeholder of `whitelist-##` or `blacklist-##`. 