### PR TITLE
Release 2.4.7

### DIFF
--- a/matterbridge-zigbee2mqtt.schema.json
+++ b/matterbridge-zigbee2mqtt.schema.json
@@ -119,6 +119,18 @@
         "selectDeviceEntityFrom": "name"
       }
     },
+    "deviceScenes": {
+      "description": "Enable the devices scenes",
+      "type": "boolean",
+      "default": false,
+      "ui:widget": "hidden"
+    },
+    "groupScenes": {
+      "description": "Enable the groups scenes",
+      "type": "boolean",
+      "default": false,
+      "ui:widget": "hidden"
+    },
     "postfix": {
       "description": "Add this unique postfix (3 characters max) to each device serial to avoid collision with other instances (you may loose the configuration of the devices in your controller when changing this value).",
       "type": "string",

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -600,7 +600,7 @@ export class ZigbeeGroup extends ZigbeeEntity {
     }
 
     // Set the device entity select
-    zigbeeGroup.log.debug(`***Group ${zigbeeGroup.en}${group.friendly_name}${db} adds select device "group-${group.id}" "${group.friendly_name}" "wifi"`);
+    // zigbeeGroup.log.debug(`***Group ${zigbeeGroup.en}${group.friendly_name}${db} adds select device "group-${group.id}" "${group.friendly_name}" "wifi"`);
     platform.setSelectDevice(`group-${group.id}`, group.friendly_name, 'wifi');
 
     let useState = false;
@@ -980,6 +980,9 @@ export class ZigbeeDevice extends ZigbeeEntity {
     if (device.friendly_name === 'Coordinator' || (device.model_id === 'ti.router' && device.manufacturer === 'TexasInstruments') || (device.model_id.startsWith('SLZB-') && device.manufacturer === 'SMLIGHT')) {
       zigbeeDevice.isRouter = true;
 
+      // zigbeeDevice.log.debug(`***Device ${zigbeeDevice.en}${device.friendly_name}${db} adds select device ${device.ieee_address} (${device.friendly_name})`);
+      platform.setSelectDevice(device.ieee_address, device.friendly_name, 'wifi');
+
       zigbeeDevice.bridgedDevice = new MatterbridgeEndpoint([doorLockDevice], { uniqueStorageKey: device.friendly_name }, zigbeeDevice.log.logLevel === LogLevel.DEBUG);
       zigbeeDevice.addBridgedDeviceBasicInformation();
       zigbeeDevice.addPowerSource();
@@ -1085,10 +1088,10 @@ export class ZigbeeDevice extends ZigbeeEntity {
     // Set the device entity select
     platform.setSelectEntity('last_seen', 'Last seen', 'hub');
     for (const [index, property] of properties.entries()) {
-      zigbeeDevice.log.debug(`***Device ${zigbeeDevice.en}${device.friendly_name}${db} adds select device ${device.ieee_address} (${device.friendly_name})`);
+      // zigbeeDevice.log.debug(`***Device ${zigbeeDevice.en}${device.friendly_name}${db} adds select device ${device.ieee_address} (${device.friendly_name})`);
       platform.setSelectDevice(device.ieee_address, device.friendly_name, 'wifi');
 
-      zigbeeDevice.log.debug(`***Device ${zigbeeDevice.en}${device.friendly_name}${db} adds select entity ${property} (${descriptions[index]})`);
+      // zigbeeDevice.log.debug(`***Device ${zigbeeDevice.en}${device.friendly_name}${db} adds select entity ${property} (${descriptions[index]})`);
       if (endpoints[index] === '') platform.setSelectEntity(property, descriptions[index], 'hub');
       platform.setSelectDeviceEntity(device.ieee_address, property, descriptions[index], 'hub');
     }
@@ -1142,7 +1145,8 @@ export class ZigbeeDevice extends ZigbeeEntity {
           if (!zigbeeDevice.mutableDevice.has(endpoint)) { zigbeeDevice.mutableDevice.set(endpoint, { tagList: [], deviceTypes: [z2m.deviceType], clusterServersIds: [...z2m.deviceType.requiredServerClusters, ClusterId(z2m.cluster)], clusterServersOptions: [], clusterClientsIds: [], clusterClientsOptions: [] });
           } else {
             zigbeeDevice.mutableDevice.get(endpoint)?.deviceTypes.push(z2m.deviceType);
-            zigbeeDevice.mutableDevice.get(endpoint)?.clusterServersIds.push(...z2m.deviceType.requiredServerClusters, ClusterId(z2m.cluster));
+            zigbeeDevice.mutableDevice.get(endpoint)?.clusterServersIds.push(...z2m.deviceType.requiredServerClusters);
+            zigbeeDevice.mutableDevice.get(endpoint)?.clusterServersIds.push(ClusterId(z2m.cluster));
           }
         } else {
           const tagList: { mfgCode: VendorId | null; namespaceId: number; tag: number; label?: string | null }[] = [];
@@ -1239,7 +1243,9 @@ export class ZigbeeDevice extends ZigbeeEntity {
 
     // Add PowerSource cluster
     zigbeeDevice.addPowerSource();
-    mainEndpoint.clusterServersIds.splice(mainEndpoint.clusterServersIds.indexOf(PowerSource.Cluster.id), 1);
+    if (mainEndpoint.clusterServersIds.includes(PowerSource.Cluster.id)) {
+      mainEndpoint.clusterServersIds.splice(mainEndpoint.clusterServersIds.indexOf(PowerSource.Cluster.id), 1);
+    }
 
     // Filter out duplicate clusters and clusters objects
     for (const [endpoint, device] of zigbeeDevice.mutableDevice) {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -699,6 +699,12 @@ export class ZigbeeGroup extends ZigbeeEntity {
       zigbeeGroup.bridgedDevice = new MatterbridgeEndpoint([deviceType, bridgedNode, powerSource], { uniqueStorageKey: group.friendly_name }, zigbeeGroup.log.logLevel === LogLevel.DEBUG);
     }
 
+    if (platform.config.groupScenes === true) {
+      group.scenes.forEach((scene) => {
+        zigbeeGroup.log.debug(`***Group ${gn}${group.friendly_name}${rs}${db} scene ${CYAN}${scene.name}${db} id ${CYAN}${scene.id}${db}`);
+      });
+    }
+
     zigbeeGroup.addBridgedDeviceBasicInformation();
     zigbeeGroup.addPowerSource();
     zigbeeGroup.bridgedDevice.addRequiredClusterServers();
@@ -1002,6 +1008,14 @@ export class ZigbeeDevice extends ZigbeeEntity {
       });
 
       return zigbeeDevice;
+    }
+
+    if (platform.config.deviceScenes === true) {
+      Object.entries(device.endpoints).forEach(([key, endpoint]) => {
+        Object.values(endpoint.scenes).forEach((scene) => {
+          zigbeeDevice.log.debug(`***Device ${dn}${device.friendly_name}${rs}${db} endpoint ${CYAN}${key}${db} scene ${CYAN}${scene.name}${db} id ${CYAN}${scene.id}${db}`);
+        });
+      });
     }
 
     // Get types and properties


### PR DESCRIPTION
## [2.4.7] - 2025-03-19

### Added

- [select]: Added the possibility to whitelist or blacklist with the device serial (i.e. 0x187a3efffe357548) or the group serial (i.e. group-1).

### Changed

- [package]: Updated package.
- [package]: Updated dependencies.
- [plugin]: Requires Matterbridge 2.2.5.
- [config]: Added parameter postfix (3 characters max) to be consistent with the other plugins. This parameter works with the Devices panel in the home page.
- [config]: The old postfixHostname will be removed in the next release. If you were using postfixHostname, please change it with postfix, the controllers will likely remove and recreate all the devices so make a backup of configurations (i.e. room assignements) and automations on the controller!

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
</a>
